### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://api.travis-ci.org/hyukhur/HHUIImageNamed.png)](https://travis-ci.org/hyukhur/HHUIImageNamed)
 [![Coverage Status](https://img.shields.io/coveralls/hyukhur/HHUIImageNamed.svg)](https://coveralls.io/r/hyukhur/HHUIImageNamed?branch=master)
 [![License](https://go-shields.herokuapp.com/license-MIT-blue.png)](http://opensource.org/licenses/MIT) [![Platform](https://cocoapod-badges.herokuapp.com/p/HHUIImageNamed/badge.png)](https://github.com/hyukhur/HHUIImageNamed/tree/master/HHUIImageNamed/Classes)
-[![Cocoapods](http://img.shields.io/cocoapods/p/HHUIImageNamed.svg)](http://cocoapods.org/?q=on%3Aios%20HHUIImageNamed)&nbsp;
+[![CocoaPods](http://img.shields.io/cocoapods/p/HHUIImageNamed.svg)](http://cocoapods.org/?q=on%3Aios%20HHUIImageNamed)&nbsp;
 
 HHUIImageNamed
 ==============


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
